### PR TITLE
Fix PagingSpliterator making extra fetch on partial page

### DIFF
--- a/radiobrowser4j/src/main/java/de/sfuhrm/radiobrowser4j/PagingSpliterator.java
+++ b/radiobrowser4j/src/main/java/de/sfuhrm/radiobrowser4j/PagingSpliterator.java
@@ -97,7 +97,7 @@ class PagingSpliterator<T> extends Spliterators.AbstractSpliterator<T> {
             currentData = fetchPage.apply(physicalPage);
             log.debug("Elements in loaded page: {}", currentData.size());
             currentDataIndex = 0;
-            if (currentData.isEmpty()) {
+            if (currentData.size() < physicalPage.getLimit()) {
                 endOfList = true;
             }
         }

--- a/radiobrowser4j/src/test/java/de/sfuhrm/radiobrowser4j/PagingSpliteratorTest.java
+++ b/radiobrowser4j/src/test/java/de/sfuhrm/radiobrowser4j/PagingSpliteratorTest.java
@@ -15,8 +15,10 @@
 */
 package de.sfuhrm.radiobrowser4j;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -126,5 +128,24 @@ public class PagingSpliteratorTest {
                 .collect(Collectors.toList());
 
         assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void testPagingSpliteratorPartialPageStopsWithoutExtraFetch() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        List<Integer> sourceData = Arrays.asList(1, 2, 3); // fewer than FETCH_SIZE_DEFAULT (128)
+
+        PagingSpliterator<Integer> spliterator = new PagingSpliterator<>(
+                paging -> {
+                    fetchCount.incrementAndGet();
+                    return paging.getOffset() == 0 ? sourceData : Collections.emptyList();
+                },
+                null
+        );
+
+        List<Integer> actual = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+
+        assertThat(actual, is(sourceData));
+        assertThat("partial page should not trigger a second fetch", fetchCount.get(), is(1));
     }
 }


### PR DESCRIPTION
## Summary

- `PagingSpliterator` was fetching the next page even when the current page returned fewer results than `FETCH_SIZE_DEFAULT` (128), causing one unnecessary API call per search that doesn't fill a full page
- A partial page unambiguously means end-of-data — only an empty page was previously treated as the stop signal
- Fix: change `currentData.isEmpty()` → `currentData.size() < physicalPage.getLimit()` in `loadPage()`

## Test plan

- Added `testPagingSpliteratorPartialPageStopsWithoutExtraFetch` which asserts `fetchCount == 1` when the data source returns 3 items (< 128); this test **fails** on the unfixed code (`fetchCount` is 2) and **passes** after the fix
- All 3 existing `PagingSpliteratorTest` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)